### PR TITLE
Fixed #42 -- Added missing alt attribute on logo

### DIFF
--- a/djangocon/templates/sitetree/menu.html
+++ b/djangocon/templates/sitetree/menu.html
@@ -6,7 +6,7 @@
     &#9776;
   </button>
   <div class="collapse navbar-toggleable-xs" id="exCollapsingNavbar2">
-    <img class="logo-full hidden-sm-down" src="{% static "assets/img/logo-full.png" %}">
+    <img class="logo-full hidden-sm-down" src="{% static "assets/img/logo-full.png" %}" alt="DjangoCon US logo">
     <ul class="nav navbar-nav">
       {% for item in sitetree_items %}
         {% if item.has_children %}


### PR DESCRIPTION
A quick `git grep -F '<img'` indicates that all other `<img>` tags have an alt attribute.