### PR TITLE
Google Cloud Storage File Backend

### DIFF
--- a/djangocon/settings/gondor.py
+++ b/djangocon/settings/gondor.py
@@ -96,3 +96,5 @@ if "GONDOR_SENDGRID_USER" in os.environ:
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 DEFAULT_HTTP_PROTOCOL = 'https'
+
+DEFAULT_FILE_STORAGE = "djangocon.storage.ECGoogleCloudStorage"

--- a/djangocon/storage.py
+++ b/djangocon/storage.py
@@ -91,6 +91,14 @@ class GoogleCloudStorage(Storage):
 
 
 class ECGoogleCloudStorage(GoogleCloudStorage):
+    """
+    Custom subclass of GoogleCloudStorage to interact with Eldarion Cloud
+
+    To create:
+
+        ec instances env GCS_CREDENTIALS=$(cat key.json | base64) GCS_BUCKET=<bucket>
+
+    """
 
     def get_oauth_credentials(self):
         client_credentials = json.loads(base64.b64decode(os.environ["GCS_CREDENTIALS"]))

--- a/djangocon/storage.py
+++ b/djangocon/storage.py
@@ -1,0 +1,101 @@
+import base64
+import json
+import mimetypes
+import os
+import uuid
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import Storage
+from django.utils.functional import SimpleLazyObject
+
+import httplib2
+
+from googleapiclient.discovery import build as discovery_build
+from googleapiclient.http import MediaIoBaseUpload
+from oauth2client.client import SERVICE_ACCOUNT, GoogleCredentials
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+def _gcs_file_storage_settings():
+    config = getattr(settings, "GCS_FILE_STORAGE", {})
+
+    def default_bucket():
+        try:
+            return os.environ["GCS_BUCKET"]
+        except KeyError:
+            raise ImproperlyConfigured("Either GCS_FILE_STORAGE[bucket] or env var GCS_BUCKET need to be set.")
+    config.setdefault("bucket", SimpleLazyObject(default_bucket))
+
+    return config
+
+
+class GoogleCloudStorage(Storage):
+    """
+    Django storage backend for Google Cloud Storage (GCS)
+
+    This storage backend uses google-api-python-client to interact with GCS. It
+    makes no assumptions about your environment and can be used anywhere.
+
+    Current State: this class only supports uploading data to GCS (read will be
+    implemented soon).
+
+    This class is planned to be moved into its own app (or in django-storages,
+    possibly). If you come across a bug with this class, contact Brian Rosner.
+    """
+
+    def __init__(self):
+        self.set_client()
+        self.bucket = _gcs_file_storage_settings()["bucket"]
+
+    def set_client(self):
+        credentials = self.get_oauth_credentials()
+        http = credentials.authorize(httplib2.Http())
+        self.client = discovery_build("storage", "v1", http=http)
+
+    def get_oauth_credentials(self):
+        return self.create_scoped(GoogleCredentials.get_application_default())
+
+    def create_scoped(self, credentials):
+        return credentials.create_scoped(["https://www.googleapis.com/auth/devstorage.read_write"])
+
+    def execute_req(self, req):
+        return req.execute()
+
+    def get_available_name(self, name, max_length):
+        _, ext = os.path.splitext(name)
+        return str(uuid.uuid4()) + ext
+
+    def _save(self, name, content):
+        mimetype, _ = mimetypes.guess_type(name)
+        if mimetype is None:
+            mimetype = "application/octet-stream"
+        media = MediaIoBaseUpload(content, mimetype)
+        req = self.client.objects().insert(
+            bucket=self.bucket,
+            name=name,
+            media_body=media,
+        )
+        self.execute_req(req)
+        return name
+
+    def get_gcs_object(self, name):
+        return self.client.objects().get(bucket=self.bucket, object=name).execute()
+
+    def url(self, name):
+        url_template = _gcs_file_storage_settings().get(
+            "url-template",
+            "https://storage.googleapis.com/{bucket}/{name}"
+        )
+        return url_template.format(bucket=self.bucket, name=name)
+
+
+class ECGoogleCloudStorage(GoogleCloudStorage):
+
+    def get_oauth_credentials(self):
+        client_credentials = json.loads(base64.b64decode(os.environ["GCS_CREDENTIALS"]))
+        if client_credentials["type"] == SERVICE_ACCOUNT:
+            creds = ServiceAccountCredentials.from_json_keyfile_dict(client_credentials)
+        else:
+            raise ImproperlyConfigured("non-service accounts are not supported")
+        return self.create_scoped(creds)

--- a/gondor.yml
+++ b/gondor.yml
@@ -3,7 +3,6 @@ buildpack: https://buildpack.gondor.io/python
 branches:
   master: primary
   development: staging
-  google-cloud-storage: google-cloud-storage
 deploy:
   services:
     - web

--- a/gondor.yml
+++ b/gondor.yml
@@ -3,6 +3,7 @@ buildpack: https://buildpack.gondor.io/python
 branches:
   master: primary
   development: staging
+  google-cloud-storage: google-cloud-storage
 deploy:
   services:
     - web

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ django-contact-form==1.2
 django-markitup==2.3.1
 django-waffle==0.10.1
 fake-factory==0.5.6
+google-api-python-client==1.5.0
 invoke==0.12.2
 pinax-blog==4.3.0
 Unipath==1.1


### PR DESCRIPTION
This enables file uploads to persist.

This PR adds a new storage backend and as noted in the docstring, it will eventually be moved elsewhere. At Eldarion, we haven't quite spent the time getting GCS working with sites running on Eldarion Cloud, so this proves an initial concept.

I have tested this code on Eldarion Cloud and it seemed to worked well for sponsor benefits. It should work without any issues on other models that use the default file backend.

primary and staging have been updated with the credentials needed to work so no further action should be needed other than merging this and deploying.