### PR TITLE
Fix broken links

### DIFF
--- a/_pages/schedule-general-sessions.html
+++ b/_pages/schedule-general-sessions.html
@@ -43,7 +43,7 @@ title: Conference Schedule
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle current_branch" data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
 <a class="current_item current_branch" href="/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>

--- a/_pages/schedule-general-sessions.html
+++ b/_pages/schedule-general-sessions.html
@@ -170,7 +170,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/14/">Readability Counts</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/14/">Readability Counts</a></h4>
 <p class="speaker">Trey Hunner</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -183,7 +183,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/37/">Django, Python, and Health Care Data</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/37/">Django, Python, and Health Care Data</a></h4>
 <p class="speaker">Becca Nock</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -201,7 +201,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/32/">Dispelling the 'Genius Programmer' Myth Through Code Review</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/32/">Dispelling the 'Genius Programmer' Myth Through Code Review</a></h4>
 <p class="speaker">Ashwini Oruganti</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -214,7 +214,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/40/">Building Dynamic Dashboards with Django and D3</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/40/">Building Dynamic Dashboards with Django and D3</a></h4>
 <p class="speaker">Clinton Dreisbach</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -232,7 +232,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/13/">Rub-a-Dub Rubber Duck: Don’t Be Afraid to Debug!</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/13/">Rub-a-Dub Rubber Duck: Don’t Be Afraid to Debug!</a></h4>
 <p class="speaker">Anna Ossowski</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -245,7 +245,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/16/">Django for IoT: From hackathon to production</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/16/">Django for IoT: From hackathon to production</a></h4>
 <p class="speaker">Anna Schneider</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -290,7 +290,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/34/">Websockets: Intro to messaging.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/34/">Websockets: Intro to messaging.</a></h4>
 <p class="speaker">Josue Balandrano Coronel</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -303,7 +303,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/11/">Under the Hood of Modern CSS Frameworks</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/11/">Under the Hood of Modern CSS Frameworks</a></h4>
 <p class="speaker">Michael Trythall</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -321,7 +321,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/64/">Django and PostgreSQL: An Ever-Closer Union</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/64/">Django and PostgreSQL: An Ever-Closer Union</a></h4>
 <p class="speaker">Christophe Pettus</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -334,7 +334,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/36/">An Intro To Web Accessibility In Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/36/">An Intro To Web Accessibility In Django</a></h4>
 <p class="speaker">Annalee Flower Horne</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -352,7 +352,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/27/">Solving problems with Django Forms.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/27/">Solving problems with Django Forms.</a></h4>
 <p class="speaker">Kirt Gittens</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -365,7 +365,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/15/">Sign Me Up - Choosing &amp; using a registration package for your Django project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/15/">Sign Me Up - Choosing &amp; using a registration package for your Django project</a></h4>
 <p class="speaker">Eleanor Stribling</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -399,7 +399,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/8/">Design for Non-Designers</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/8/">Design for Non-Designers</a></h4>
 <p class="speaker">Tracy Osborn</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -412,7 +412,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/30/">How We Used NLP and Django to Build a Movie Suggestion Website &amp; Twitterbot</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/30/">How We Used NLP and Django to Build a Movie Suggestion Website &amp; Twitterbot</a></h4>
 <p class="speaker">Vince Salvino</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -430,7 +430,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/29/">SSL all the things</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/29/">SSL all the things</a></h4>
 <p class="speaker">Markus Holtermann</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -443,7 +443,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/45/">Building JSON APIs with Django / Pinax</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/45/">Building JSON APIs with Django / Pinax</a></h4>
 <p class="speaker">Brian Rosner</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -461,7 +461,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/53/">Pushing the Pony’s boundaries — Django Admin Customization</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/53/">Pushing the Pony’s boundaries — Django Admin Customization</a></h4>
 <p class="speaker">Ola Sitarska</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -474,7 +474,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/38/">A new look into APIs - Graphene</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/38/">A new look into APIs - Graphene</a></h4>
 <p class="speaker">Syrus Akbary</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -556,7 +556,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/23/">Things your mother didn't teach you about sharing your toys</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/23/">Things your mother didn't teach you about sharing your toys</a></h4>
 <p class="speaker">Russell Keith-Magee</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -569,7 +569,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/12/">Confident Asset Deployments with Webpack &amp; Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/12/">Confident Asset Deployments with Webpack &amp; Django</a></h4>
 <p class="speaker">Scott Burns</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -587,7 +587,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/48/">Just Enough Typography</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/48/">Just Enough Typography</a></h4>
 <p class="speaker">Joni Trythall</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -600,7 +600,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/17/">Spicing up Django: An introduction to Mezzanine CMS</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/17/">Spicing up Django: An introduction to Mezzanine CMS</a></h4>
 <p class="speaker">Ed Rivas</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -645,7 +645,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/49/">Django Supporting Virtual Reality Game Development</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/49/">Django Supporting Virtual Reality Game Development</a></h4>
 <p class="speaker">Rudy Mutter</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -658,7 +658,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/41/">The Full Stack of User Experience</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/41/">The Full Stack of User Experience</a></h4>
 <p class="speaker">Alicia C. Raciti</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -675,7 +675,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/50/">High-Availability Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/50/">High-Availability Django</a></h4>
 <p class="speaker">Frankie Dintino</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -688,7 +688,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/39/">Making the most Out of Code Reviews</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/39/">Making the most Out of Code Reviews</a></h4>
 <p class="speaker">Mariatta Wijaya</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -706,7 +706,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/21/">The impact of women learning to code in developing countries: benefits and challenges.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/21/">The impact of women learning to code in developing countries: benefits and challenges.</a></h4>
 <p class="speaker">Aisha Bello, Ibrahim Diop</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -718,7 +718,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/65/">Making a splash with your open source project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/65/">Making a splash with your open source project</a></h4>
 <p class="speaker">Russell Keith-Magee</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -752,7 +752,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/28/">The Fraud Police are Coming: Work, Leadership, and Imposter Syndrome</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/28/">The Fraud Police are Coming: Work, Leadership, and Imposter Syndrome</a></h4>
 <p class="speaker">Amanda Clark, Briana Morgan</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -764,7 +764,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/26/">Walking Down the A11y Road - Lessons Learnt from Working on Accessibility of a Django Project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/26/">Walking Down the A11y Road - Lessons Learnt from Working on Accessibility of a Django Project</a></h4>
 <p class="speaker">Radina Matic</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -781,7 +781,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/62/">Mighty Model Managers</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/62/">Mighty Model Managers</a></h4>
 <p class="speaker">Shawn Inman</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -794,7 +794,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/42/">Angular 2 and You</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/42/">Angular 2 and You</a></h4>
 <p class="speaker">Pam Selle</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -812,7 +812,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/43/">I Didn't Know QuerySets Could Do That</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/43/">I Didn't Know QuerySets Could Do That</a></h4>
 <p class="speaker">Charlie Guo</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -825,7 +825,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/35/">Stress Testing your Code of Conduct in Production</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/35/">Stress Testing your Code of Conduct in Production</a></h4>
 <p class="speaker">Baptiste Mispelon, Ola Sendecka</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -906,7 +906,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/18/">It Is Darkest Before Dawn: Alcoholism and Addiction in Tech (CW) (TW)</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/18/">It Is Darkest Before Dawn: Alcoholism and Addiction in Tech (CW) (TW)</a></h4>
 <p class="speaker">Timothy Allen</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -918,7 +918,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/31/">This Old Pony: Working with Legacy Django Apps</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/31/">This Old Pony: Working with Legacy Django Apps</a></h4>
 <p class="speaker">Ben Lopatin</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -963,7 +963,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/10/">Frog and Toad Learn About Django Security</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/10/">Frog and Toad Learn About Django Security</a></h4>
 <p class="speaker">Philip James</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -976,7 +976,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/9/">Healthy Minds in a Healthy Community</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/9/">Healthy Minds in a Healthy Community</a></h4>
 <p class="speaker">Erik Romijn</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -993,7 +993,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/52/">Entomology 101: Effective Bug Hunting</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/52/">Entomology 101: Effective Bug Hunting</a></h4>
 <p class="speaker">Frank Wiles</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1006,7 +1006,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/25/">People are coming to my beginning workshop, what now?</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/25/">People are coming to my beginning workshop, what now?</a></h4>
 <p class="speaker">Nicholle James</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1024,7 +1024,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/33/">Beyond PO: How to make Django work for right-to-left languages</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/33/">Beyond PO: How to make Django work for right-to-left languages</a></h4>
 <p class="speaker">Cho Garcia</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1037,7 +1037,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/22/">Git in Control, Version Control and How it Could Save Your Life</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/22/">Git in Control, Version Control and How it Could Save Your Life</a></h4>
 <p class="speaker">Rachell Calhoun</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1071,7 +1071,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/46/">Django and React: Perfect Together</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/46/">Django and React: Perfect Together</a></h4>
 <p class="speaker">Jack McCloy</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -1084,7 +1084,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/19/">From Developer to Manager</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/19/">From Developer to Manager</a></h4>
 <p class="speaker">Sean O'Connor</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1101,7 +1101,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/54/">The City as Cyborg: a history of Civic Technology in the first quarter of the 21st Century</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/54/">The City as Cyborg: a history of Civic Technology in the first quarter of the 21st Century</a></h4>
 <p class="speaker">Mjumbe Poe</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1113,7 +1113,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/51/">Atomic Wagtail</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/51/">Atomic Wagtail</a></h4>
 <p class="speaker">Kurt Wall</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">

--- a/_pages/schedule-presentation-10.html
+++ b/_pages/schedule-presentation-10.html
@@ -43,8 +43,8 @@ title: 'Presentation: Frog and Toad Learn About Django Security'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-11.html
+++ b/_pages/schedule-presentation-11.html
@@ -43,8 +43,8 @@ title: 'Presentation: Under the Hood of Modern CSS Frameworks'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-12.html
+++ b/_pages/schedule-presentation-12.html
@@ -43,8 +43,8 @@ title: 'Presentation: Confident Asset Deployments with Webpack & Django'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-13.html
+++ b/_pages/schedule-presentation-13.html
@@ -43,8 +43,8 @@ title: "Presentation: Rub-a-Dub Rubber Duck: Don\u2019t Be Afraid to Debug!"
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-14.html
+++ b/_pages/schedule-presentation-14.html
@@ -43,8 +43,8 @@ title: 'Presentation: Readability Counts'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-15.html
+++ b/_pages/schedule-presentation-15.html
@@ -44,8 +44,8 @@ title: 'Presentation: Sign Me Up - Choosing & using a registration package for y
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-16.html
+++ b/_pages/schedule-presentation-16.html
@@ -43,8 +43,8 @@ title: 'Presentation: Django for IoT: From hackathon to production'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-17.html
+++ b/_pages/schedule-presentation-17.html
@@ -43,8 +43,8 @@ title: 'Presentation: Spicing up Django: An introduction to Mezzanine CMS'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-18.html
+++ b/_pages/schedule-presentation-18.html
@@ -44,8 +44,8 @@ title: 'Presentation: It Is Darkest Before Dawn: Alcoholism and Addiction in Tec
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-19.html
+++ b/_pages/schedule-presentation-19.html
@@ -43,8 +43,8 @@ title: 'Presentation: From Developer to Manager'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-21.html
+++ b/_pages/schedule-presentation-21.html
@@ -44,8 +44,8 @@ title: 'Presentation: The impact of women learning to code in developing countri
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-22.html
+++ b/_pages/schedule-presentation-22.html
@@ -43,8 +43,8 @@ title: 'Presentation: Git in Control, Version Control and How it Could Save Your
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-23.html
+++ b/_pages/schedule-presentation-23.html
@@ -43,8 +43,8 @@ title: 'Presentation: Things your mother didn''t teach you about sharing your to
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-25.html
+++ b/_pages/schedule-presentation-25.html
@@ -43,8 +43,8 @@ title: 'Presentation: People are coming to my beginning workshop, what now?'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-26.html
+++ b/_pages/schedule-presentation-26.html
@@ -44,8 +44,8 @@ title: 'Presentation: Walking Down the A11y Road - Lessons Learnt from Working o
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-27.html
+++ b/_pages/schedule-presentation-27.html
@@ -43,8 +43,8 @@ title: 'Presentation: Solving problems with Django Forms.'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-28.html
+++ b/_pages/schedule-presentation-28.html
@@ -44,8 +44,8 @@ title: 'Presentation: The Fraud Police are Coming: Work, Leadership, and Imposte
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-29.html
+++ b/_pages/schedule-presentation-29.html
@@ -43,8 +43,8 @@ title: 'Presentation: SSL all the things'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-30.html
+++ b/_pages/schedule-presentation-30.html
@@ -44,8 +44,8 @@ title: 'Presentation: How We Used NLP and Django to Build a Movie Suggestion Web
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-31.html
+++ b/_pages/schedule-presentation-31.html
@@ -43,8 +43,8 @@ title: 'Presentation: This Old Pony: Working with Legacy Django Apps'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-32.html
+++ b/_pages/schedule-presentation-32.html
@@ -43,8 +43,8 @@ title: 'Presentation: Dispelling the ''Genius Programmer'' Myth Through Code Rev
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-33.html
+++ b/_pages/schedule-presentation-33.html
@@ -43,8 +43,8 @@ title: 'Presentation: Beyond PO: How to make Django work for right-to-left langu
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-34.html
+++ b/_pages/schedule-presentation-34.html
@@ -43,8 +43,8 @@ title: 'Presentation: Websockets: Intro to messaging.'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-35.html
+++ b/_pages/schedule-presentation-35.html
@@ -43,8 +43,8 @@ title: 'Presentation: Stress Testing your Code of Conduct in Production'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-36.html
+++ b/_pages/schedule-presentation-36.html
@@ -43,8 +43,8 @@ title: 'Presentation: An Intro To Web Accessibility In Django'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-37.html
+++ b/_pages/schedule-presentation-37.html
@@ -43,8 +43,8 @@ title: 'Presentation: Django, Python, and Health Care Data'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-38.html
+++ b/_pages/schedule-presentation-38.html
@@ -43,8 +43,8 @@ title: 'Presentation: A new look into APIs - Graphene'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-39.html
+++ b/_pages/schedule-presentation-39.html
@@ -43,8 +43,8 @@ title: 'Presentation: Making the most Out of Code Reviews'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-40.html
+++ b/_pages/schedule-presentation-40.html
@@ -43,8 +43,8 @@ title: 'Presentation: Building Dynamic Dashboards with Django and D3'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-41.html
+++ b/_pages/schedule-presentation-41.html
@@ -43,8 +43,8 @@ title: 'Presentation: The Full Stack of User Experience'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-42.html
+++ b/_pages/schedule-presentation-42.html
@@ -43,8 +43,8 @@ title: 'Presentation: Angular 2 and You'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-43.html
+++ b/_pages/schedule-presentation-43.html
@@ -43,8 +43,8 @@ title: 'Presentation: I Didn''t Know QuerySets Could Do That'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-45.html
+++ b/_pages/schedule-presentation-45.html
@@ -43,8 +43,8 @@ title: 'Presentation: Building JSON APIs with Django / Pinax'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-46.html
+++ b/_pages/schedule-presentation-46.html
@@ -43,8 +43,8 @@ title: 'Presentation: Django and React: Perfect Together'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-48.html
+++ b/_pages/schedule-presentation-48.html
@@ -43,8 +43,8 @@ title: 'Presentation: Just Enough Typography'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-49.html
+++ b/_pages/schedule-presentation-49.html
@@ -43,8 +43,8 @@ title: 'Presentation: Django Supporting Virtual Reality Game Development'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-50.html
+++ b/_pages/schedule-presentation-50.html
@@ -43,8 +43,8 @@ title: 'Presentation: High-Availability Django'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-51.html
+++ b/_pages/schedule-presentation-51.html
@@ -43,8 +43,8 @@ title: 'Presentation: Atomic Wagtail'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-52.html
+++ b/_pages/schedule-presentation-52.html
@@ -43,8 +43,8 @@ title: 'Presentation: Entomology 101: Effective Bug Hunting'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-53.html
+++ b/_pages/schedule-presentation-53.html
@@ -43,8 +43,8 @@ title: "Presentation: Pushing the Pony\u2019s boundaries \u2014 Django Admin Cus
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-54.html
+++ b/_pages/schedule-presentation-54.html
@@ -44,8 +44,8 @@ title: 'Presentation: The City as Cyborg: a history of Civic Technology in the f
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-55.html
+++ b/_pages/schedule-presentation-55.html
@@ -43,8 +43,8 @@ title: 'Presentation: An Introduction to Secure Web Development with Django (and
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-56.html
+++ b/_pages/schedule-presentation-56.html
@@ -43,8 +43,8 @@ title: 'Presentation: Designing Good User Experience'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-57.html
+++ b/_pages/schedule-presentation-57.html
@@ -43,8 +43,8 @@ title: 'Presentation: Grow Your Twitter Bot Garden'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-59.html
+++ b/_pages/schedule-presentation-59.html
@@ -43,8 +43,8 @@ title: 'Presentation: Hello Web App Workshop'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-60.html
+++ b/_pages/schedule-presentation-60.html
@@ -43,8 +43,8 @@ title: 'Presentation: Demystifying the Django REST Framework'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-62.html
+++ b/_pages/schedule-presentation-62.html
@@ -43,8 +43,8 @@ title: 'Presentation: Mighty Model Managers'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-64.html
+++ b/_pages/schedule-presentation-64.html
@@ -43,8 +43,8 @@ title: 'Presentation: Django and PostgreSQL: An Ever-Closer Union'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-65.html
+++ b/_pages/schedule-presentation-65.html
@@ -43,8 +43,8 @@ title: 'Presentation: Making a splash with your open source project'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-8.html
+++ b/_pages/schedule-presentation-8.html
@@ -43,8 +43,8 @@ title: 'Presentation: Design for Non-Designers'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-presentation-9.html
+++ b/_pages/schedule-presentation-9.html
@@ -43,8 +43,8 @@ title: 'Presentation: Healthy Minds in a Healthy Community'
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule-tutorials.html
+++ b/_pages/schedule-tutorials.html
@@ -127,7 +127,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-45)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/55/">An Introduction to Secure Web Development with Django (and Python!)</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/55/">An Introduction to Secure Web Development with Django (and Python!)</a></h4>
 <p class="speaker">James Bennett</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -139,7 +139,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-50)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/56/">Designing Good User Experience</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/56/">Designing Good User Experience</a></h4>
 <p class="speaker">Žan Anderle</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -152,7 +152,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-55)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/59/">Hello Web App Workshop</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/59/">Hello Web App Workshop</a></h4>
 <p class="speaker">Tracy Osborn</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -186,7 +186,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-45)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/60/">Demystifying the Django REST Framework</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/60/">Demystifying the Django REST Framework</a></h4>
 <p class="speaker">Haris Ibrahim K V</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -199,7 +199,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-50)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/57/">Grow Your Twitter Bot Garden</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/57/">Grow Your Twitter Bot Garden</a></h4>
 <p class="speaker">Terian Koscik</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>

--- a/_pages/schedule-tutorials.html
+++ b/_pages/schedule-tutorials.html
@@ -44,7 +44,7 @@ title: Conference Schedule
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle current_branch" data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
 <a class="current_item current_branch" href="/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -43,8 +43,8 @@ title: Conference Schedule
 <li class="nav-item dropdown">
 <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle " data-toggle="dropdown" href="/#" role="button">Schedule</a>
 <div class="dropdown-menu">
-<a class="dropdown-item" href="/tutorials/">Tutorial Schedule</a>
-<a class="dropdown-item" href="/general-sessions/">Talk Schedule</a>
+<a class="dropdown-item" href="/schedule/tutorials/">Tutorial Schedule</a>
+<a class="dropdown-item" href="/schedule/general-sessions/">Talk Schedule</a>
 <a class="dropdown-item" href="/sprints/">Sprints</a>
 <a class="dropdown-item" href="/orientation/">Day 1 Orientation</a>
 <a class="dropdown-item" href="/reception/">Opening Reception/Bowling Night</a>

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -131,7 +131,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-45)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/55/">An Introduction to Secure Web Development with Django (and Python!)</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/55/">An Introduction to Secure Web Development with Django (and Python!)</a></h4>
 <p class="speaker">James Bennett</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -143,7 +143,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-50)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/56/">Designing Good User Experience</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/56/">Designing Good User Experience</a></h4>
 <p class="speaker">Žan Anderle</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -156,7 +156,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-55)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/59/">Hello Web App Workshop</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/59/">Hello Web App Workshop</a></h4>
 <p class="speaker">Tracy Osborn</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -190,7 +190,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-45)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/60/">Demystifying the Django REST Framework</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/60/">Demystifying the Django REST Framework</a></h4>
 <p class="speaker">Haris Ibrahim K V</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -203,7 +203,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-50)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/57/">Grow Your Twitter Bot Garden</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/57/">Grow Your Twitter Bot Garden</a></h4>
 <p class="speaker">Terian Koscik</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -311,7 +311,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/14/">Readability Counts</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/14/">Readability Counts</a></h4>
 <p class="speaker">Trey Hunner</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -324,7 +324,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/37/">Django, Python, and Health Care Data</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/37/">Django, Python, and Health Care Data</a></h4>
 <p class="speaker">Becca Nock</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -342,7 +342,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/32/">Dispelling the 'Genius Programmer' Myth Through Code Review</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/32/">Dispelling the 'Genius Programmer' Myth Through Code Review</a></h4>
 <p class="speaker">Ashwini Oruganti</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -355,7 +355,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/40/">Building Dynamic Dashboards with Django and D3</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/40/">Building Dynamic Dashboards with Django and D3</a></h4>
 <p class="speaker">Clinton Dreisbach</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -373,7 +373,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/13/">Rub-a-Dub Rubber Duck: Don’t Be Afraid to Debug!</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/13/">Rub-a-Dub Rubber Duck: Don’t Be Afraid to Debug!</a></h4>
 <p class="speaker">Anna Ossowski</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -386,7 +386,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/16/">Django for IoT: From hackathon to production</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/16/">Django for IoT: From hackathon to production</a></h4>
 <p class="speaker">Anna Schneider</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -431,7 +431,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/34/">Websockets: Intro to messaging.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/34/">Websockets: Intro to messaging.</a></h4>
 <p class="speaker">Josue Balandrano Coronel</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -444,7 +444,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/11/">Under the Hood of Modern CSS Frameworks</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/11/">Under the Hood of Modern CSS Frameworks</a></h4>
 <p class="speaker">Michael Trythall</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -462,7 +462,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/64/">Django and PostgreSQL: An Ever-Closer Union</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/64/">Django and PostgreSQL: An Ever-Closer Union</a></h4>
 <p class="speaker">Christophe Pettus</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -475,7 +475,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/36/">An Intro To Web Accessibility In Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/36/">An Intro To Web Accessibility In Django</a></h4>
 <p class="speaker">Annalee Flower Horne</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -493,7 +493,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/27/">Solving problems with Django Forms.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/27/">Solving problems with Django Forms.</a></h4>
 <p class="speaker">Kirt Gittens</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -506,7 +506,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/15/">Sign Me Up - Choosing &amp; using a registration package for your Django project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/15/">Sign Me Up - Choosing &amp; using a registration package for your Django project</a></h4>
 <p class="speaker">Eleanor Stribling</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -540,7 +540,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/8/">Design for Non-Designers</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/8/">Design for Non-Designers</a></h4>
 <p class="speaker">Tracy Osborn</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -553,7 +553,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/30/">How We Used NLP and Django to Build a Movie Suggestion Website &amp; Twitterbot</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/30/">How We Used NLP and Django to Build a Movie Suggestion Website &amp; Twitterbot</a></h4>
 <p class="speaker">Vince Salvino</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -571,7 +571,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/29/">SSL all the things</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/29/">SSL all the things</a></h4>
 <p class="speaker">Markus Holtermann</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -584,7 +584,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/45/">Building JSON APIs with Django / Pinax</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/45/">Building JSON APIs with Django / Pinax</a></h4>
 <p class="speaker">Brian Rosner</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -602,7 +602,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/53/">Pushing the Pony’s boundaries — Django Admin Customization</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/53/">Pushing the Pony’s boundaries — Django Admin Customization</a></h4>
 <p class="speaker">Ola Sitarska</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -615,7 +615,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/38/">A new look into APIs - Graphene</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/38/">A new look into APIs - Graphene</a></h4>
 <p class="speaker">Syrus Akbary</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -697,7 +697,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/23/">Things your mother didn't teach you about sharing your toys</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/23/">Things your mother didn't teach you about sharing your toys</a></h4>
 <p class="speaker">Russell Keith-Magee</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -710,7 +710,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/12/">Confident Asset Deployments with Webpack &amp; Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/12/">Confident Asset Deployments with Webpack &amp; Django</a></h4>
 <p class="speaker">Scott Burns</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -728,7 +728,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/48/">Just Enough Typography</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/48/">Just Enough Typography</a></h4>
 <p class="speaker">Joni Trythall</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -741,7 +741,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/17/">Spicing up Django: An introduction to Mezzanine CMS</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/17/">Spicing up Django: An introduction to Mezzanine CMS</a></h4>
 <p class="speaker">Ed Rivas</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -786,7 +786,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/49/">Django Supporting Virtual Reality Game Development</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/49/">Django Supporting Virtual Reality Game Development</a></h4>
 <p class="speaker">Rudy Mutter</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -799,7 +799,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/41/">The Full Stack of User Experience</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/41/">The Full Stack of User Experience</a></h4>
 <p class="speaker">Alicia C. Raciti</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -816,7 +816,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/50/">High-Availability Django</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/50/">High-Availability Django</a></h4>
 <p class="speaker">Frankie Dintino</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -829,7 +829,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/39/">Making the most Out of Code Reviews</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/39/">Making the most Out of Code Reviews</a></h4>
 <p class="speaker">Mariatta Wijaya</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -847,7 +847,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/21/">The impact of women learning to code in developing countries: benefits and challenges.</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/21/">The impact of women learning to code in developing countries: benefits and challenges.</a></h4>
 <p class="speaker">Aisha Bello, Ibrahim Diop</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -859,7 +859,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/65/">Making a splash with your open source project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/65/">Making a splash with your open source project</a></h4>
 <p class="speaker">Russell Keith-Magee</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -893,7 +893,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/28/">The Fraud Police are Coming: Work, Leadership, and Imposter Syndrome</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/28/">The Fraud Police are Coming: Work, Leadership, and Imposter Syndrome</a></h4>
 <p class="speaker">Amanda Clark, Briana Morgan</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -905,7 +905,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/26/">Walking Down the A11y Road - Lessons Learnt from Working on Accessibility of a Django Project</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/26/">Walking Down the A11y Road - Lessons Learnt from Working on Accessibility of a Django Project</a></h4>
 <p class="speaker">Radina Matic</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -922,7 +922,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/62/">Mighty Model Managers</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/62/">Mighty Model Managers</a></h4>
 <p class="speaker">Shawn Inman</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -935,7 +935,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/42/">Angular 2 and You</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/42/">Angular 2 and You</a></h4>
 <p class="speaker">Pam Selle</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -953,7 +953,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/43/">I Didn't Know QuerySets Could Do That</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/43/">I Didn't Know QuerySets Could Do That</a></h4>
 <p class="speaker">Charlie Guo</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -966,7 +966,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/35/">Stress Testing your Code of Conduct in Production</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/35/">Stress Testing your Code of Conduct in Production</a></h4>
 <p class="speaker">Baptiste Mispelon, Ola Sendecka</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1047,7 +1047,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/18/">It Is Darkest Before Dawn: Alcoholism and Addiction in Tech (CW) (TW)</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/18/">It Is Darkest Before Dawn: Alcoholism and Addiction in Tech (CW) (TW)</a></h4>
 <p class="speaker">Timothy Allen</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1059,7 +1059,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/31/">This Old Pony: Working with Legacy Django Apps</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/31/">This Old Pony: Working with Legacy Django Apps</a></h4>
 <p class="speaker">Ben Lopatin</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -1104,7 +1104,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/10/">Frog and Toad Learn About Django Security</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/10/">Frog and Toad Learn About Django Security</a></h4>
 <p class="speaker">Philip James</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -1117,7 +1117,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/9/">Healthy Minds in a Healthy Community</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/9/">Healthy Minds in a Healthy Community</a></h4>
 <p class="speaker">Erik Romijn</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1134,7 +1134,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/52/">Entomology 101: Effective Bug Hunting</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/52/">Entomology 101: Effective Bug Hunting</a></h4>
 <p class="speaker">Frank Wiles</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1147,7 +1147,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/25/">People are coming to my beginning workshop, what now?</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/25/">People are coming to my beginning workshop, what now?</a></h4>
 <p class="speaker">Nicholle James</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1165,7 +1165,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/33/">Beyond PO: How to make Django work for right-to-left languages</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/33/">Beyond PO: How to make Django work for right-to-left languages</a></h4>
 <p class="speaker">Cho Garcia</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1178,7 +1178,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/22/">Git in Control, Version Control and How it Could Save Your Life</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/22/">Git in Control, Version Control and How it Could Save Your Life</a></h4>
 <p class="speaker">Rachell Calhoun</p>
 <span class="label label-pill label-level">Novice Level</span>
 </div>
@@ -1212,7 +1212,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/46/">Django and React: Perfect Together</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/46/">Django and React: Perfect Together</a></h4>
 <p class="speaker">Jack McCloy</p>
 <span class="label label-pill label-level">Intermediate or Advanced Level</span>
 </div>
@@ -1225,7 +1225,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/19/">From Developer to Manager</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/19/">From Developer to Manager</a></h4>
 <p class="speaker">Sean O'Connor</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1242,7 +1242,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Auditorium (G-06)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/54/">The City as Cyborg: a history of Civic Technology in the first quarter of the 21st Century</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/54/">The City as Cyborg: a history of Civic Technology in the first quarter of the 21st Century</a></h4>
 <p class="speaker">Mjumbe Poe</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">
@@ -1254,7 +1254,7 @@ Tutorials are a separate registration and are $150 per session. <a href="https:/
 <span>Classroom (F-95)</span>
 </div>
 <div class="card-block schedule-block">
-<h4 class="card-title"><a href="/presentation/51/">Atomic Wagtail</a></h4>
+<h4 class="card-title"><a href="/schedule/presentation/51/">Atomic Wagtail</a></h4>
 <p class="speaker">Kurt Wall</p>
 </div>
 <div class="schedule-card-footer card-footer text-muted">


### PR DESCRIPTION
This change fixes a bunch of broken links across two commits (messages included below).

---
Fix broken links

The links to presentations are missing their `/schedule` prefix and 404
on the website currently served at https://2016.djangocon.us/. This
change fixes the links from the schedule pages to specific presentation
detail pages.

---
Fix navbar links

On some (but not all) pages, the navbar links to `/tutorials/` and
`/general-sessions/` instead of their canonical `/schedule`-prefixed
permalinks. This change bulk-updates all of those links to fix 404s on
the archived site.

---